### PR TITLE
Support any language with JS style block comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,5 @@ extensions: [
 ```
 
 And that's it! This will only do anything if your CodeMirror
-is using the JavaScript or TypeScript mode.
+is using a language that supports `/* */` style block comments,
+like JavaScript and TypeScript.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,18 @@ import { javascriptLanguage } from "@codemirror/lang-javascript";
 import { syntaxTree } from "@codemirror/language";
 import {
   EditorSelection,
+  type EditorState,
   type SelectionRange,
   type StateCommand,
 } from "@codemirror/state";
 import type { KeyBinding } from "@codemirror/view";
+
+const able = (state: EditorState, range: SelectionRange) => {
+  // Don't do anything if we're not in JavaScript mode.
+  // This should also cover TypeScript, which is just
+  // JavaScript with extra configuration.
+  return range.empty && javascriptLanguage.isActiveAt(state, range.from)
+}
 
 /**
  * This is modeled after the CodeMirror Markdown mode's
@@ -22,11 +30,9 @@ export const insertNewlineContinueComment: StateCommand = ({
   const { doc } = state;
   let dont: null | { range: SelectionRange } = null;
   const changes = state.changeByRange((range) => {
-    // Don't do anything if we're not in JavaScript mode.
-    // This should also cover TypeScript, which is just
-    // JavaScript with extra configuration.
-    if (!range.empty || !javascriptLanguage.isActiveAt(state, range.from))
+    if (!able(state, range))
       return (dont = { range });
+
     const pos = range.from;
     const line = doc.lineAt(pos);
 
@@ -82,10 +88,7 @@ export const maybeCloseBlockComment: StateCommand = ({ state, dispatch }) => {
   const { doc } = state;
   let dont: null | { range: SelectionRange } = null;
   const changes = state.changeByRange((range) => {
-    // Don't do anything if we're not in JavaScript mode.
-    // This should also cover TypeScript, which is just
-    // JavaScript with extra configuration.
-    if (!range.empty || !javascriptLanguage.isActiveAt(state, range.from))
+    if (!able(state, range))
       return (dont = { range });
     const pos = range.from;
     const line = doc.lineAt(pos);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,28 @@ import {
 } from "@codemirror/state";
 import type { KeyBinding } from "@codemirror/view";
 
+// commentTokens: {line: "//", block: {open: "/*", close: "*/"}},
+interface Block {
+  open: string | null,
+  close: string | null
+}
+interface CommentTokens {
+  line: string | null,
+  block: Block | null
+}
+
 const able = (state: EditorState, range: SelectionRange) => {
-  // Don't do anything if we're not in JavaScript mode.
-  // This should also cover TypeScript, which is just
-  // JavaScript with extra configuration.
-  return range.empty && javascriptLanguage.isActiveAt(state, range.from)
+  if (range.empty) {
+    const data = state.languageDataAt<CommentTokens>("commentTokens", range.from);
+    for (let i = 0; i < data.length; i++) {
+      const block = data[i]?.block;
+      if (block
+          && (block.open === "/*")
+          && (block.close === "*/"))
+        return true;
+    }
+  }
+  return false
 }
 
 /**


### PR DESCRIPTION
## What

Instead of checking whether JS is active, check whether there is a language active that has `/* ... */` style comments.

## Why

This adds support for languages like Rust and C.
