### PR TITLE
Get the indentation from the position of the BlockComment

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,100 @@
+import { insertNewlineContinueComment } from '../src/index.js';
+import { javascript } from "@codemirror/lang-javascript";
 import { test, expect } from "vitest";
+import {
+  EditorState,
+  type Text,
+  type Transaction,
+} from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
 
-test("pass", () => {
-  expect(1).toEqual(1);
-});
+function insert(text, pos) {
+  let tr: any;
+
+  function dispatch(tr1: Transaction) {
+    tr = tr1
+  }
+  let state = EditorState.create({
+    doc: text,
+    extensions: [
+      javascript({
+        typescript: true,
+        jsx: true,
+      }),
+    ]
+  });
+
+  state = state.update({
+    selection: { anchor: pos, head: pos }
+  }).state;
+
+  tr = null;
+  insertNewlineContinueComment({ state, dispatch: dispatch });
+
+  let doc: Text
+  if (tr)
+    doc = tr.state.doc
+  else
+    doc = state.doc;
+
+  return doc?.toString();
+}
+
+test("/*", () => {
+  const doc = "/* abc";
+  const end = "/* abc\n * ";
+  expect(insert(doc, doc.length)).toEqual(end);
+})
+
+test("/**", () => {
+  const doc = "/** abc";
+  const end = "/** abc\n * ";
+  expect(insert(doc, doc.length)).toEqual(end);
+})
+
+
+test("midway; ", () => {
+  const doc = "/** abc";
+  expect(insert(doc, doc.length - 2)).toEqual(doc);
+})
+
+test("after code", () => {
+  const doc = `
+let a = 1; /** abc`;
+  const end = doc + `
+            * `;
+  expect(insert(doc, doc.length)).toEqual(end);
+})
+
+test("indented", () => {
+  const doc = `
+/** Comment */
+function increment(num: number) {
+  /** indented
+  return num + 1;
+}
+/** Continue`
+
+  const end = `
+/** Comment */
+function increment(num: number) {
+  /** indented
+   * 
+  return num + 1;
+}
+/** Continue`;
+
+  expect(insert(doc, 64)).toEqual(end);
+})
+
+test("earlier close missing", () => {
+  const doc = `
+let a /* forgot to close this...
+
+/* ...so this will align with the one above`
+
+  const end = doc + `
+       * `;
+
+  expect(insert(doc, doc.length)).toEqual(end);
+})

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,7 +8,7 @@ import {
 } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 
-function insert(text, pos) {
+function insert(text: string, pos: number) {
   let tr: any;
 
   function dispatch(tr1: Transaction) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,15 +71,15 @@ export const insertNewlineContinueComment: StateCommand = ({
         return (dont = { range });
       }
 
-      const indentation = line.text.match(/^([^\*\/]+)([\*|\/])/);
-      let indentStr = indentation?.[1] || " ";
-
-      // If continuing from /**,
-      // we want an extra space of indentation
-      // to match the second *
-      if (indentation?.[2] === "/") {
-        indentStr = `${indentStr} `;
+      const startLine = doc.lineAt(node.from)
+      let offset = node.from - startLine.from
+      if (offset < 0) {
+        // Something went wrong.
+        return (dont = { range });
       }
+      offset++ // Line up with the *.
+
+      let indentStr = " ".repeat(offset)
       const insert = `${state.lineBreak}${indentStr}* `;
 
       return {


### PR DESCRIPTION
## What

Instead of using a regex to fill out the new line, use the position of the BlockComment syntax node (relative to the line the comment starts on) and fill with spaces.

Also add some tests.

## Why

Using the syntax node is simpler. Indenting with space means that
```js
 let a; /* abc
```
becomes
```js
let a; /* abc
        * 
```
instead of
```js
let a; /* abc
let a;  * 
```

Also this prepares things to solve the `restOfLine` TODO.

A side effect of using the node is that now if you have a comment further up in the file that you forgot to close, then the indentation will be relative to that comment. See test "earlier close missing" for an example. I think this is pretty rare, so a small price to pay, but if you hate it I'm happy to try with a regex or just submit the tests :)
