### PR TITLE
Apply continuations only inside JSDoc comments

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -38,8 +38,7 @@ function insert(text: string, pos: number, char = " ") {
 
 test("/*", () => {
   const doc = "/* abc";
-  const end = "/* abc\n * ";
-  expect(insert(doc, doc.length)).toEqual([end, end.length]);
+  expect(insert(doc, doc.length)).toEqual([doc, doc.length]);
 });
 
 test("/**", () => {
@@ -68,10 +67,10 @@ test("midway with trim", () => {
 
 test("midway on second line", () => {
   const doc = `
-/* @brief Add one.
+/** @brief Add one.
  * This is a longish sentence that will be split in two.`;
   const end = `
-/* @brief Add one.
+/** @brief Add one.
  * This is a longish sentence that will be split
  * in two.`;
   expect(insert(doc, doc.length - " in two.".length)).toEqual([
@@ -141,9 +140,9 @@ function increment(num: number) {
 
 test("earlier close missing", () => {
   const doc = `
-let a /* forgot to close this...
+let a /** forgot to close this...
 
-/* ...so this will align with the one above`;
+/** ...so this will align with the one above`;
 
   const end = `${doc}
        * `;
@@ -181,7 +180,7 @@ test("at end slash", () => {
 
 test("previous comment ends on line", () => {
   const doc = `
-/*export*/ function f() { /* description `;
+/*export*/ function f() { /** description `;
   const end = `${doc}
                            * `;
   expect(insert(doc, doc.length)).toEqual([end, end.length]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,13 @@ interface CommentTokens {
   block: Block | null;
 }
 
+const isJsDocBlock = (doc: Text, node: SyntaxNode) => {
+  return (
+    node.name === "BlockComment" &&
+    doc.sliceString(node.from, node.from + 3) === "/**"
+  );
+};
+
 const atCommentToken = (doc: Text, pos: number, node: SyntaxNode) => {
   return (
     // Either */<HERE> or *<HERE>/.
@@ -66,7 +73,7 @@ export const insertNewlineContinueComment: StateCommand = ({
 
     const node = tree.resolveInner(pos, -1);
 
-    if (node.name === "BlockComment") {
+    if (isJsDocBlock(doc, node)) {
       // If the cursor is at the */ token, do not continue.
       if (atCommentToken(doc, pos, node)) {
         return (dont = { range });
@@ -122,7 +129,7 @@ export const maybeCloseBlockComment: StateCommand = ({ state, dispatch }) => {
 
     const node = tree.resolveInner(pos, -1);
 
-    if (node.name === "BlockComment") {
+    if (isJsDocBlock(doc, node)) {
       // If this line is the comment ending, do not
       // continue.
       if (line.text.match(/\*\//)) {


### PR DESCRIPTION
Fixes #61

This PR ensures that continuations are only applied within JSDoc block comments.

I had Claude update the tests and verify that none of them are redundant. It called out the cases `"/**"` and `"after code"` as being very similar but still justified.